### PR TITLE
Add Flask budget management API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.pyc
+instance/
+budget.db
+*.sqlite3
+.env
+.venv/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,72 @@
-README.md
+# Kişisel Ev Bütçesi (Flask)
+
+Bu proje, ev bütçenizi yönetebilmeniz için basit fakat genişletilebilir bir Flask uygulaması sunar. Aşağıdaki temel modüller desteklenir:
+
+- **Harcamalar** – Harcamaları kaydedebilir, bir harcamayı parçalarına bölebilir veya taksit bilgisi girebilirsiniz.
+- **Harcama Kaynakları** – Harcama kaynağını (kredi kartı, nakit, borç vb.) tanımlayabilirsiniz.
+- **Borçlar** – Borçlarınızı izleyebilirsiniz.
+- **Gelirler** – Maaş veya ek gelirleri kaydedebilirsiniz.
+
+## Başlangıç
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # Windows için: .venv\\Scripts\\activate
+pip install -r requirements.txt
+flask --app app --debug run
+```
+
+İlk defa çalıştırmadan önce örnek verilerle veritabanını başlatabilirsiniz:
+
+```bash
+flask --app app init-db
+```
+
+Bu komut `budget.db` dosyasını oluşturur ve örnek gelir/harcama/borç kayıtları ekler.
+
+## API Uç Noktaları
+
+| Yöntem | Yol | Açıklama |
+| --- | --- | --- |
+| GET | `/` | API hakkında bilgi verir |
+| GET/POST | `/sources` | Harcama kaynaklarını listele/ekle |
+| GET/PUT/DELETE | `/sources/<id>` | Kaynak detayları |
+| GET/POST | `/expenses` | Harcamaları listele/ekle (bölme ve taksit desteği) |
+| GET/PUT/DELETE | `/expenses/<id>` | Harcama detayları |
+| GET/POST | `/incomes` | Gelirleri listele/ekle |
+| GET/PUT/DELETE | `/incomes/<id>` | Gelir detayları |
+| GET/POST | `/debts` | Borçları listele/ekle |
+| GET/PUT/DELETE | `/debts/<id>` | Borç detayları |
+
+### Örnek İstek: Taksitli Harcama
+
+```bash
+curl -X POST http://localhost:5000/expenses \
+  -H "Content-Type: application/json" \
+  -d '{
+        "description": "Laptop",
+        "amount": 24000,
+        "date": "2024-04-18",
+        "category": "Teknoloji",
+        "source_id": 1,
+        "installment": {"count": 12, "number": 1, "amount": 2000},
+        "splits": [
+            {"name": "İş", "amount": 16000},
+            {"name": "Kişisel", "amount": 8000}
+        ]
+      }'
+```
+
+Uygulama JSON çıktıları döndürür ve böylece frontend veya mobil bir uygulama tarafından kolayca tüketilebilir.
+
+## Test
+
+Projede hazır bir test takımı bulunmuyor. Değişiklik yaptıktan sonra en azından kodun sözdizimini kontrol etmek için aşağıdaki komutu çalıştırabilirsiniz:
+
+```bash
+python -m compileall .
+```
+
+## Lisans
+
+MIT lisansı altında dağıtılmaktadır.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,7 @@
+from budget_app import create_app
+
+app = create_app()
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/budget_app/__init__.py
+++ b/budget_app/__init__.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+
+
+db = SQLAlchemy()
+
+
+def create_app(test_config: dict | None = None) -> Flask:
+    """Application factory for the budget manager API."""
+    app = Flask(__name__)
+    app.config.from_mapping(
+        SQLALCHEMY_DATABASE_URI="sqlite:///budget.db",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+        JSON_SORT_KEYS=False,
+    )
+
+    if test_config:
+        app.config.update(test_config)
+
+    db.init_app(app)
+
+    from . import routes  # noqa: WPS433  (import inside function for factory pattern)
+    app.register_blueprint(routes.bp)
+
+    from .cli import register_cli
+
+    register_cli(app)
+
+    @app.get("/health")
+    def health_check() -> dict[str, str]:
+        """Simple health endpoint useful for smoke testing."""
+        return {"status": "ok"}
+
+    return app

--- a/budget_app/cli.py
+++ b/budget_app/cli.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import json
+from datetime import date, timedelta
+from decimal import Decimal
+
+import click
+from flask import current_app
+from flask.cli import with_appcontext
+
+from . import db
+from .models import Debt, Expense, Income, Source
+
+
+@click.command("init-db")
+@with_appcontext
+def init_db_command() -> None:
+    """Initialize the SQLite database with demo data."""
+    db_path = current_app.config["SQLALCHEMY_DATABASE_URI"]
+    click.echo(f"Initializing database at {db_path}")
+    db.drop_all()
+    db.create_all()
+
+    seed_sources()
+    seed_incomes()
+    seed_expenses()
+    seed_debts()
+
+    db.session.commit()
+    click.echo("Database initialized with sample records.")
+
+
+def seed_sources() -> None:
+    sources = [
+        Source(name="Kredi Kartı", type="credit_card"),
+        Source(name="Nakit", type="cash"),
+        Source(name="Borç", type="debt"),
+    ]
+    db.session.add_all(sources)
+
+
+def seed_incomes() -> None:
+    salary = Income(
+        source="Maaş",
+        amount=Decimal("35000.00"),
+        received_date=date.today().replace(day=1),
+        category="Salary",
+        notes="Ana gelir kaynağı",
+    )
+    freelance = Income(
+        source="Serbest İş",
+        amount=Decimal("5500.00"),
+        received_date=date.today() - timedelta(days=10),
+        category="Freelance",
+        notes="Web sitesi tasarımı projesi",
+    )
+    db.session.add_all([salary, freelance])
+
+
+def seed_expenses() -> None:
+    card_source = Source.query.filter_by(type="credit_card").first()
+    cash_source = Source.query.filter_by(type="cash").first()
+    debt_source = Source.query.filter_by(type="debt").first()
+
+    groceries = Expense(
+        description="Market alışverişi",
+        amount=Decimal("1250.30"),
+        date=date.today() - timedelta(days=2),
+        category="Food",
+        source=card_source,
+        split_details=json.dumps([
+            {"name": "Gıda", "amount": 900.30},
+            {"name": "Temizlik", "amount": 350.00},
+        ]),
+        notes="Haftalık alışveriş",
+    )
+
+    rent_installment = Expense(
+        description="Kira taksidi",
+        amount=Decimal("7500.00"),
+        date=date.today(),
+        category="Housing",
+        source=debt_source,
+        installment_count=12,
+        installment_number=5,
+        installment_amount=Decimal("7500.00"),
+        notes="Ev sahibi ile yapılan taksit anlaşması",
+    )
+
+    fuel = Expense(
+        description="Benzin",
+        amount=Decimal("850.75"),
+        date=date.today() - timedelta(days=1),
+        category="Transportation",
+        source=cash_source,
+        notes="Şehir içi kullanım",
+    )
+
+    db.session.add_all([groceries, rent_installment, fuel])
+
+
+def seed_debts() -> None:
+    rent_debt = Debt(
+        creditor="Ev Sahibi",
+        amount=Decimal("90000.00"),
+        due_date=date.today() + timedelta(days=240),
+        status="active",
+        notes="12 taksitli kira borcu",
+    )
+    credit_card = Debt(
+        creditor="Banka X",
+        amount=Decimal("5400.00"),
+        due_date=date.today() + timedelta(days=20),
+        status="active",
+        notes="Kredi kartı ekstresi",
+    )
+    db.session.add_all([rent_debt, credit_card])
+
+
+def register_cli(app) -> None:
+    app.cli.add_command(init_db_command)

--- a/budget_app/models.py
+++ b/budget_app/models.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import json
+from datetime import date
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy import CheckConstraint, Date, ForeignKey, Integer, Numeric, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from . import db
+
+
+class Source(db.Model):
+    __tablename__ = "sources"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(120), unique=True, nullable=False)
+    type: Mapped[str] = mapped_column(String(30), nullable=False)
+
+    expenses: Mapped[list["Expense"]] = relationship("Expense", back_populates="source")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"id": self.id, "name": self.name, "type": self.type}
+
+
+class Expense(db.Model):
+    __tablename__ = "expenses"
+    __table_args__ = (
+        CheckConstraint("amount >= 0", name="expense_amount_positive"),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    description: Mapped[str] = mapped_column(String(255), nullable=False)
+    amount: Mapped[Decimal] = mapped_column(Numeric(12, 2), nullable=False)
+    date: Mapped[date] = mapped_column(Date, nullable=False)
+    category: Mapped[str | None] = mapped_column(String(100))
+    notes: Mapped[str | None] = mapped_column(Text)
+
+    source_id: Mapped[int] = mapped_column(ForeignKey("sources.id"), nullable=False)
+    source: Mapped[Source] = relationship("Source", back_populates="expenses")
+
+    split_details: Mapped[str | None] = mapped_column(Text)
+    installment_count: Mapped[int | None] = mapped_column(Integer)
+    installment_number: Mapped[int | None] = mapped_column(Integer)
+    installment_amount: Mapped[Decimal | None] = mapped_column(Numeric(12, 2))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "description": self.description,
+            "amount": float(self.amount),
+            "date": self.date.isoformat(),
+            "category": self.category,
+            "source": self.source.to_dict() if self.source else None,
+            "splits": self.splits,
+            "installment": self.installment_info,
+            "notes": self.notes,
+        }
+
+    @property
+    def splits(self) -> list[dict[str, Any]] | None:
+        if not self.split_details:
+            return None
+        try:
+            details = json.loads(self.split_details)
+        except json.JSONDecodeError:
+            return None
+        return details
+
+    @splits.setter
+    def splits(self, value: list[dict[str, Any]] | None) -> None:
+        self.split_details = json.dumps(value) if value else None
+
+    @property
+    def installment_info(self) -> dict[str, Any] | None:
+        if self.installment_count is None:
+            return None
+        return {
+            "count": self.installment_count,
+            "number": self.installment_number,
+            "amount": float(self.installment_amount) if self.installment_amount is not None else None,
+        }
+
+
+class Income(db.Model):
+    __tablename__ = "incomes"
+    __table_args__ = (
+        CheckConstraint("amount >= 0", name="income_amount_positive"),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    source: Mapped[str] = mapped_column(String(120), nullable=False)
+    amount: Mapped[Decimal] = mapped_column(Numeric(12, 2), nullable=False)
+    received_date: Mapped[date] = mapped_column(Date, nullable=False)
+    category: Mapped[str | None] = mapped_column(String(100))
+    notes: Mapped[str | None] = mapped_column(Text)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "source": self.source,
+            "amount": float(self.amount),
+            "received_date": self.received_date.isoformat(),
+            "category": self.category,
+            "notes": self.notes,
+        }
+
+
+class Debt(db.Model):
+    __tablename__ = "debts"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    creditor: Mapped[str] = mapped_column(String(120), nullable=False)
+    amount: Mapped[Decimal] = mapped_column(Numeric(12, 2), nullable=False)
+    due_date: Mapped[date | None] = mapped_column(Date)
+    status: Mapped[str | None] = mapped_column(String(30))
+    notes: Mapped[str | None] = mapped_column(Text)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "creditor": self.creditor,
+            "amount": float(self.amount),
+            "due_date": self.due_date.isoformat() if self.due_date else None,
+            "status": self.status,
+            "notes": self.notes,
+        }

--- a/budget_app/routes.py
+++ b/budget_app/routes.py
@@ -1,0 +1,384 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from flask import Blueprint, jsonify, request
+
+from . import db
+from .models import Debt, Expense, Income, Source
+
+bp = Blueprint("api", __name__)
+
+
+@bp.get("/")
+def index() -> Any:
+    """Return a high level overview of the API endpoints."""
+    return jsonify(
+        {
+            "message": "Kişisel Bütçe API'sine hoş geldiniz",
+            "endpoints": {
+                "GET /sources": "Harcamalarda kullanılabilecek kaynakları listeler",
+                "POST /sources": "Yeni harcama kaynağı oluşturur",
+                "GET /expenses": "Harcamaları listeler",
+                "POST /expenses": "Yeni harcama kaydı ekler (bölünmüş ya da taksitli olabilir)",
+                "GET /debts": "Borçları listeler",
+                "POST /debts": "Yeni borç kaydı ekler",
+                "GET /incomes": "Gelirleri listeler",
+                "POST /incomes": "Yeni gelir kaydı ekler",
+            },
+        }
+    )
+
+
+@bp.route("/sources", methods=["GET", "POST"])
+def sources() -> Any:
+    if request.method == "GET":
+        all_sources = Source.query.order_by(Source.name).all()
+        return jsonify([source.to_dict() for source in all_sources])
+
+    data = request.get_json(silent=True) or {}
+    name = data.get("name")
+    source_type = data.get("type")
+    if not name or not source_type:
+        return jsonify({"error": "name ve type alanları gereklidir"}), 400
+
+    new_source = Source(name=name, type=source_type)
+    db.session.add(new_source)
+    db.session.commit()
+    return jsonify(new_source.to_dict()), 201
+
+
+@bp.route("/sources/<int:source_id>", methods=["GET", "PUT", "DELETE"])
+def source_detail(source_id: int) -> Any:
+    source = Source.query.get_or_404(source_id)
+
+    if request.method == "GET":
+        return jsonify(source.to_dict())
+
+    if request.method == "DELETE":
+        db.session.delete(source)
+        db.session.commit()
+        return "", 204
+
+    data = request.get_json(silent=True) or {}
+    source.name = data.get("name", source.name)
+    source.type = data.get("type", source.type)
+    db.session.commit()
+    return jsonify(source.to_dict())
+
+
+@bp.route("/expenses", methods=["GET", "POST"])
+def expenses() -> Any:
+    if request.method == "GET":
+        all_expenses = Expense.query.order_by(Expense.date.desc()).all()
+        return jsonify([expense.to_dict() for expense in all_expenses])
+
+    data = request.get_json(silent=True) or {}
+    description = data.get("description")
+    amount = parse_amount(data.get("amount"))
+    date_value = parse_date(data.get("date")) or datetime.utcnow().date()
+    category = data.get("category")
+    notes = data.get("notes")
+    source_id = data.get("source_id")
+
+    if not description or amount is None or source_id is None:
+        return (
+            jsonify({"error": "description, amount ve source_id alanları gereklidir"}),
+            400,
+        )
+
+    source = Source.query.get(source_id)
+    if source is None:
+        return jsonify({"error": "Geçersiz kaynak"}), 400
+
+    expense = Expense(
+        description=description,
+        amount=amount,
+        date=date_value,
+        category=category,
+        notes=notes,
+        source=source,
+    )
+
+    split_items = data.get("splits")
+    if split_items:
+        valid_splits = validate_splits(split_items)
+        if valid_splits is None:
+            return jsonify({"error": "splits listesi hatalı"}), 400
+        expense.splits = valid_splits
+
+    installment = data.get("installment")
+    if installment:
+        valid_installment = validate_installment(installment)
+        if valid_installment is None:
+            return jsonify({"error": "installment bilgisi hatalı"}), 400
+        expense.installment_count = valid_installment["count"]
+        expense.installment_number = valid_installment["number"]
+        expense.installment_amount = valid_installment["amount"]
+
+    db.session.add(expense)
+    db.session.commit()
+    return jsonify(expense.to_dict()), 201
+
+
+@bp.route("/expenses/<int:expense_id>", methods=["GET", "PUT", "DELETE"])
+def expense_detail(expense_id: int) -> Any:
+    expense = Expense.query.get_or_404(expense_id)
+
+    if request.method == "GET":
+        return jsonify(expense.to_dict())
+
+    if request.method == "DELETE":
+        db.session.delete(expense)
+        db.session.commit()
+        return "", 204
+
+    data = request.get_json(silent=True) or {}
+
+    if "description" in data:
+        expense.description = data["description"]
+    if "amount" in data:
+        amount = parse_amount(data["amount"])
+        if amount is None:
+            return jsonify({"error": "amount değeri geçersiz"}), 400
+        expense.amount = amount
+    if "date" in data:
+        date_value = parse_date(data["date"])
+        if date_value is None:
+            return jsonify({"error": "date değeri geçersiz"}), 400
+        expense.date = date_value
+    if "category" in data:
+        expense.category = data["category"]
+    if "notes" in data:
+        expense.notes = data["notes"]
+    if "source_id" in data:
+        source = Source.query.get(data["source_id"])
+        if source is None:
+            return jsonify({"error": "Geçersiz kaynak"}), 400
+        expense.source = source
+    if "splits" in data:
+        splits = data["splits"]
+        if splits:
+            valid_splits = validate_splits(splits)
+            if valid_splits is None:
+                return jsonify({"error": "splits listesi hatalı"}), 400
+            expense.splits = valid_splits
+        else:
+            expense.splits = None
+    if "installment" in data:
+        installment = data["installment"]
+        if installment:
+            valid_installment = validate_installment(installment)
+            if valid_installment is None:
+                return jsonify({"error": "installment bilgisi hatalı"}), 400
+            expense.installment_count = valid_installment["count"]
+            expense.installment_number = valid_installment["number"]
+            expense.installment_amount = valid_installment["amount"]
+        else:
+            expense.installment_count = None
+            expense.installment_number = None
+            expense.installment_amount = None
+
+    db.session.commit()
+    return jsonify(expense.to_dict())
+
+
+@bp.route("/incomes", methods=["GET", "POST"])
+def incomes() -> Any:
+    if request.method == "GET":
+        all_incomes = Income.query.order_by(Income.received_date.desc()).all()
+        return jsonify([income.to_dict() for income in all_incomes])
+
+    data = request.get_json(silent=True) or {}
+    source = data.get("source")
+    amount = parse_amount(data.get("amount"))
+    received_date = parse_date(data.get("received_date")) or datetime.utcnow().date()
+    category = data.get("category")
+    notes = data.get("notes")
+
+    if not source or amount is None:
+        return jsonify({"error": "source ve amount alanları gereklidir"}), 400
+
+    income = Income(
+        source=source,
+        amount=amount,
+        received_date=received_date,
+        category=category,
+        notes=notes,
+    )
+
+    db.session.add(income)
+    db.session.commit()
+    return jsonify(income.to_dict()), 201
+
+
+@bp.route("/incomes/<int:income_id>", methods=["GET", "PUT", "DELETE"])
+def income_detail(income_id: int) -> Any:
+    income = Income.query.get_or_404(income_id)
+
+    if request.method == "GET":
+        return jsonify(income.to_dict())
+
+    if request.method == "DELETE":
+        db.session.delete(income)
+        db.session.commit()
+        return "", 204
+
+    data = request.get_json(silent=True) or {}
+
+    if "source" in data:
+        income.source = data["source"]
+    if "amount" in data:
+        amount = parse_amount(data["amount"])
+        if amount is None:
+            return jsonify({"error": "amount değeri geçersiz"}), 400
+        income.amount = amount
+    if "received_date" in data:
+        received_date = parse_date(data["received_date"])
+        if received_date is None:
+            return jsonify({"error": "received_date değeri geçersiz"}), 400
+        income.received_date = received_date
+    if "category" in data:
+        income.category = data["category"]
+    if "notes" in data:
+        income.notes = data["notes"]
+
+    db.session.commit()
+    return jsonify(income.to_dict())
+
+
+@bp.route("/debts", methods=["GET", "POST"])
+def debts() -> Any:
+    if request.method == "GET":
+        all_debts = Debt.query.order_by(Debt.due_date.is_(None), Debt.due_date).all()
+        return jsonify([debt.to_dict() for debt in all_debts])
+
+    data = request.get_json(silent=True) or {}
+    creditor = data.get("creditor")
+    amount = parse_amount(data.get("amount"))
+    due_date = parse_date(data.get("due_date"))
+    status = data.get("status")
+    notes = data.get("notes")
+
+    if not creditor or amount is None:
+        return jsonify({"error": "creditor ve amount alanları gereklidir"}), 400
+
+    debt = Debt(
+        creditor=creditor,
+        amount=amount,
+        due_date=due_date,
+        status=status,
+        notes=notes,
+    )
+
+    db.session.add(debt)
+    db.session.commit()
+    return jsonify(debt.to_dict()), 201
+
+
+@bp.route("/debts/<int:debt_id>", methods=["GET", "PUT", "DELETE"])
+def debt_detail(debt_id: int) -> Any:
+    debt = Debt.query.get_or_404(debt_id)
+
+    if request.method == "GET":
+        return jsonify(debt.to_dict())
+
+    if request.method == "DELETE":
+        db.session.delete(debt)
+        db.session.commit()
+        return "", 204
+
+    data = request.get_json(silent=True) or {}
+
+    if "creditor" in data:
+        debt.creditor = data["creditor"]
+    if "amount" in data:
+        amount = parse_amount(data["amount"])
+        if amount is None:
+            return jsonify({"error": "amount değeri geçersiz"}), 400
+        debt.amount = amount
+    if "due_date" in data:
+        due_date = parse_date(data["due_date"])
+        if due_date is None:
+            return jsonify({"error": "due_date değeri geçersiz"}), 400
+        debt.due_date = due_date
+    if "status" in data:
+        debt.status = data["status"]
+    if "notes" in data:
+        debt.notes = data["notes"]
+
+    db.session.commit()
+    return jsonify(debt.to_dict())
+
+
+def parse_amount(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError, TypeError):
+        return None
+
+
+def parse_date(value: Any) -> date | None:
+    if value is None:
+        return None
+    if isinstance(value, date) and not isinstance(value, datetime):
+        return value
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value).date()
+        except ValueError:
+            try:
+                return datetime.strptime(value, "%Y-%m-%d").date()
+            except ValueError:
+                return None
+    if isinstance(value, (int, float)):
+        try:
+            return datetime.fromtimestamp(value).date()
+        except (ValueError, OSError, OverflowError):
+            return None
+    return None
+
+
+def validate_splits(splits: Any) -> list[dict[str, Any]] | None:
+    if not isinstance(splits, list):
+        return None
+    cleaned: list[dict[str, Any]] = []
+    for item in splits:
+        if not isinstance(item, dict):
+            return None
+        name = item.get("name")
+        amount = parse_amount(item.get("amount"))
+        if not name or amount is None:
+            return None
+        cleaned.append({"name": name, "amount": float(amount)})
+    return cleaned
+
+
+def validate_installment(installment: Any) -> dict[str, Any] | None:
+    if not isinstance(installment, dict):
+        return None
+    count = installment.get("count")
+    number = installment.get("number")
+    amount = parse_amount(installment.get("amount"))
+
+    if count is None or number is None:
+        return None
+    try:
+        count_int = int(count)
+        number_int = int(number)
+    except (TypeError, ValueError):
+        return None
+    if count_int <= 0 or number_int <= 0 or number_int > count_int:
+        return None
+
+    return {
+        "count": count_int,
+        "number": number_int,
+        "amount": amount if amount is not None else None,
+    }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask>=3.0
+Flask-SQLAlchemy>=3.0
+click>=8.1


### PR DESCRIPTION
## Summary
- scaffold a Flask application factory with SQLAlchemy models for sources, expenses, incomes, and debts
- implement JSON APIs for managing expenses with split and installment details plus incomes, debts, and sources
- add CLI helpers to initialize the SQLite database with example data and document usage in README

## Testing
- python -m compileall .


------
https://chatgpt.com/codex/tasks/task_e_68c9182b9ca0832ab1116396e9372a00