### PR TITLE
Create tables on app startup

### DIFF
--- a/budget_app/__init__.py
+++ b/budget_app/__init__.py
@@ -21,6 +21,9 @@ def create_app(test_config: dict | None = None) -> Flask:
 
     db.init_app(app)
 
+    with app.app_context():
+        db.create_all()
+
     from . import routes  # noqa: WPS433  (import inside function for factory pattern)
     app.register_blueprint(routes.bp)
 


### PR DESCRIPTION
## Summary
- ensure the database schema is created during application startup by invoking `db.create_all()` inside an application context

## Testing
- python -m compileall .
- python app.py *(fails: ModuleNotFoundError: No module named 'flask' because dependencies could not be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc038d24e4832a9315bd82b77c9cb2